### PR TITLE
Update mirror workflow to replace GitHub URLs

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,7 +1,5 @@
 name: Mirror to Codeberg
-
 on: [push, delete]
-
 jobs:
   mirror:
     runs-on: ubuntu-latest
@@ -10,6 +8,34 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
+
+      # Replace GitHub project URLs with Codeberg equivalents in markdown files.
+      # This commit is local-only and never pushed back to GitHub; the mirror
+      # action below then forwards the modified state to Codeberg.
+      - name: Replace GitHub URLs with Codeberg URLs in markdown files
+        run: |
+          GITHUB_URL="https://github.com/richbl/go-ble-sync-cycle"
+          CODEBERG_URL="https://codeberg.org/richbl/go-ble-sync-cycle"
+
+          # Replace in README.md (repo root)
+          [ -f README.md ] && \
+            sed -i "s|${GITHUB_URL}|${CODEBERG_URL}|g" README.md
+
+          # Replace in all .md files under wiki/ (if the directory exists)
+          if [ -d wiki ]; then
+            find wiki -name "*.md" \
+              -exec sed -i "s|${GITHUB_URL}|${CODEBERG_URL}|g" {} +
+          fi
+
+          # Commit locally only if changes were made.
+          # This commit is never pushed to GitHub — only forwarded to Codeberg
+          # by the mirror action below.
+          if ! git diff --quiet; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore: replace GitHub URLs with Codeberg URLs"
+          fi
 
       # pixta-dev/repository-mirroring-action@v1.1.1
       - uses: pixta-dev/repository-mirroring-action@674e65a7d483ca28dafaacba0d07351bdcc8bd75


### PR DESCRIPTION
This workflow replaces GitHub URLs with Codeberg URLs in markdown files and commits the changes locally before mirroring to Codeberg.